### PR TITLE
Update start.sh

### DIFF
--- a/docker-config/start.sh
+++ b/docker-config/start.sh
@@ -14,7 +14,7 @@ if [ $1 == 'shibboleth' ]; then
   exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
 else
   sed -i "s#http:\/\/localhost:8081#${PROTOCOL}://${VIRTUAL_HOST}#g" /etc/mellon/mellon_metadata.xml
-  mkdir /var/www/html/mellon/sp
+  mkdir -p /var/www/html/mellon/sp
   cp -a /etc/mellon/mellon_metadata.xml /var/www/html/mellon/sp/metadata.xml
   
   sed -i "s#\# ServerName.*#ServerName ${PROTOCOL}://${VIRTUAL_HOST}#g" /etc/apache2/sites-available/mod_auth_mellon.conf


### PR DESCRIPTION
Added `-p` for `mkdir` in order to avoid getting error if the container does not start a the first time and `/var/www/html/mellon/sp` folder already exists.